### PR TITLE
Refactor obsolete code

### DIFF
--- a/com.ibm.ditatools.svg-diagrams/build_svg-diagrams.xml
+++ b/com.ibm.ditatools.svg-diagrams/build_svg-diagrams.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:dita="http://dita-ot.sourceforge.net" name="svg-syntax-as-preprocess-step">
+<project xmlns:dita="http://dita-ot.sourceforge.net" name="svg-syntax-as-preprocess-step"
+  xmlns:if="ant:if"
+  xmlns:unless="ant:unless">
 
   <target name="svg-syntax-as-preprocess-step" depends="svg-syntax-as-preprocess-step.init, svg-syntax-as-preprocess-step.run">
       
@@ -51,25 +53,26 @@
     <pipeline message="Diagrams to SVG" taskname="svgdiagrams">
       <xslt basedir="${dita.temp.dir}" 
             reloadstylesheet="${dita.preprocess.reloadstylesheet.svgdiagrams}" 
+            filenameparameter="FILENAME"
             style="${dita.plugin.com.ibm.ditatools.svg-diagrams.dir}/xsl/stage1-ddita-shell.xsl">
-        <includesfile name="${dita.temp.dir}/${fullditatopicfile}"/>
-        <param name="CSS" expression="${args.css.file}" if="args.css.file"/>
-        <param name="CSSPATH" expression="${user.csspath}" if="user.csspath"/>
-        <param name="OUTEXT" expression="${out.ext}" if="out.ext"/>
-        <param name="plus-temp-directory" expression="${plus.map.temp.dir.url}" if="plus.map.temp.dir.url"/>
+        <ditafileset format="dita" processingRole="normal"/>
+        <param name="CSS" expression="${args.css.file}" if:set="args.css.file"/>
+        <param name="CSSPATH" expression="${user.csspath}" if:set="user.csspath"/>
+        <param name="OUTEXT" expression="${out.ext}" if:set="out.ext"/>
+        <param name="plus-temp-directory" expression="${plus.map.temp.dir.url}" if:set="plus.map.temp.dir.url"/>
 
-        <param name="plus-svgobject-format" expression="${plus.svgobject.format}" if="plus.svgobject.format"/>
-        <param name="plus-svgobject-raster-mimetype" expression="${plus.svgobject.raster.mimetype}" if="plus.svgobject.raster.mimetype"/>
-        <param name="plus-svgobject-object-convert-to-path" expression="${plus.svgobject.object.convert-to-path}" if="plus.svgobject.object.convert-to-path"/>
-        <param name="plus-svgobject-raster-imagemap" expression="${plus.svgobject.raster.imagemap}" if="plus.svgobject.raster.imagemap"/>
-        <param name="plus-svgobject-path" expression="${plus.svgobject.path}" if="plus.svgobject.path"/>
-        <param name="plus-syntaxdiagram-format" expression="${plus.syntaxdiagram.format}" if="plus.syntaxdiagram.format"/>
-        <param name="plus-allhtml-syntaxdiagram-svginline-csspath" expression="${plus-allhtml-syntaxdiagram-svginline.csspath}" if="plus-allhtml-syntaxdiagram-svginline.csspath"/>
-        <param name="plus-allhtml-syntaxdiagram-svginline-jspath" expression="${plus-allhtml-syntaxdiagram-svginline.jspath}" if="plus-allhtml-syntaxdiagram-svginline.jspath"/>
-        <param name="plus-allhtml-syntaxdiagram-svgobject-csspath" expression="${plus-allhtml-syntaxdiagram-svgobject.csspath}" if="plus-allhtml-syntaxdiagram-svgobject.csspath"/>
-        <param name="plus-allhtml-syntaxdiagram-svgobject-jspath" expression="${plus-allhtml-syntaxdiagram-svgobject.jspath}" if="plus-allhtml-syntaxdiagram-svgobject.jspath"/>
-        <param name="input.map.url" expression="${html5.map.url}" if="html5.map.url"/> 
-        <param name="nav-toc" expression="${html5.nav-toc}" if="html5.nav-toc"/>
+        <param name="plus-svgobject-format" expression="${plus.svgobject.format}" if:set="plus.svgobject.format"/>
+        <param name="plus-svgobject-raster-mimetype" expression="${plus.svgobject.raster.mimetype}" if:set="plus.svgobject.raster.mimetype"/>
+        <param name="plus-svgobject-object-convert-to-path" expression="${plus.svgobject.object.convert-to-path}" if:set="plus.svgobject.object.convert-to-path"/>
+        <param name="plus-svgobject-raster-imagemap" expression="${plus.svgobject.raster.imagemap}" if:set="plus.svgobject.raster.imagemap"/>
+        <param name="plus-svgobject-path" expression="${plus.svgobject.path}" if:set="plus.svgobject.path"/>
+        <param name="plus-syntaxdiagram-format" expression="${plus.syntaxdiagram.format}" if:set="plus.syntaxdiagram.format"/>
+        <param name="plus-allhtml-syntaxdiagram-svginline-csspath" expression="${plus-allhtml-syntaxdiagram-svginline.csspath}" if:set="plus-allhtml-syntaxdiagram-svginline.csspath"/>
+        <param name="plus-allhtml-syntaxdiagram-svginline-jspath" expression="${plus-allhtml-syntaxdiagram-svginline.jspath}" if:set="plus-allhtml-syntaxdiagram-svginline.jspath"/>
+        <param name="plus-allhtml-syntaxdiagram-svgobject-csspath" expression="${plus-allhtml-syntaxdiagram-svgobject.csspath}" if:set="plus-allhtml-syntaxdiagram-svgobject.csspath"/>
+        <param name="plus-allhtml-syntaxdiagram-svgobject-jspath" expression="${plus-allhtml-syntaxdiagram-svgobject.jspath}" if:set="plus-allhtml-syntaxdiagram-svgobject.jspath"/>
+        <param name="input.map.url" expression="${html5.map.url}" if:set="html5.map.url"/> 
+        <param name="nav-toc" expression="${html5.nav-toc}" if:set="html5.nav-toc"/>
 
         <xmlcatalog refid="dita.catalog"/>
       </xslt>

--- a/com.moldflow.dita.plus-allhtml-svgobject/build_plus-allhtml-svgobject.xml
+++ b/com.moldflow.dita.plus-allhtml-svgobject/build_plus-allhtml-svgobject.xml
@@ -315,7 +315,7 @@
   </target>
 
   <target name="plus-allhtml-svgobject.copy-files.css.to-output" depends="plus-allhtml-svgobject.copy-files.css.to-output.check" if="plus-allhtml-svgobject.copy-files.css.to-output.required">
-    <condition property="syntax.diagram.css.output.directory" value="${output.dir}/${csspath}">
+    <condition property="syntax.diagram.css.output.directory" value="${dita.output.dir}/${csspath}">
       <not><isset property="syntax.diagram.css.output.directory"/></not>
     </condition>
     <copy todir="${syntax.diagram.css.output.directory}">
@@ -339,7 +339,7 @@
   </target>
 
   <target name="plus-allhtml-svgobject.copy-files.js.to-output" depends="plus-allhtml-svgobject.copy-files.js.to-output.check" if="plus-allhtml-svgobject.copy-files.js.to-output.required">
-    <copy todir="${output.dir}/${jspath}">
+    <copy todir="${dita.output.dir}/${jspath}">
       <fileset refid="fileset"/>
     </copy>
   </target>
@@ -351,7 +351,7 @@
   </target>
 
   <target name="plus-allhtml-svgobject.gen-file.js.to-output" depends="plus-allhtml-svgobject.copy-files.js.to-output.check" if="plus-allhtml-svgobject.copy-files.js.to-output.required">
-    <xslt style="${style}" in="${in}" out="${output.dir}/${jspath}/${out}"/>
+    <xslt style="${style}" in="${in}" out="${dita.output.dir}/${jspath}/${out}"/>
   </target>
 
 </project>

--- a/com.moldflow.dita.plus-allhtml-svgobject/build_plus-allhtml-svgobject_template.xml
+++ b/com.moldflow.dita.plus-allhtml-svgobject/build_plus-allhtml-svgobject_template.xml
@@ -92,7 +92,7 @@
       </and>
     </condition>
 
-    <condition property="syntax.diagram.output.directory" value="${output.dir}${file.separator}${plus.svgobject.path}">
+    <condition property="syntax.diagram.output.directory" value="${dita.output.dir}${file.separator}${plus.svgobject.path}">
       <not><isset property="syntax.diagram.output.directory"/></not>
     </condition>
 
@@ -265,7 +265,7 @@
 
   <target name="plus-allhtml-svgobject.copy-files.css.to-output" depends="plus-allhtml-svgobject.copy-files.css.to-output.check"
     if="plus-allhtml-svgobject.copy-files.css.to-output.required">
-    <condition property="syntax.diagram.css.output.directory" value="${output.dir}/${csspath}">
+    <condition property="syntax.diagram.css.output.directory" value="${dita.output.dir}/${csspath}">
       <not><isset property="syntax.diagram.css.output.directory"/></not>
     </condition>
     <copy todir="${syntax.diagram.css.output.directory}">
@@ -291,7 +291,7 @@
 
   <target name="plus-allhtml-svgobject.copy-files.js.to-output" depends="plus-allhtml-svgobject.copy-files.js.to-output.check"
     if="plus-allhtml-svgobject.copy-files.js.to-output.required">
-    <copy todir="${output.dir}/${jspath}">
+    <copy todir="${dita.output.dir}/${jspath}">
       <fileset refid="fileset"/>
     </copy>
   </target>
@@ -305,7 +305,7 @@
 
   <target name="plus-allhtml-svgobject.gen-file.js.to-output" depends="plus-allhtml-svgobject.copy-files.js.to-output.check"
     if="plus-allhtml-svgobject.copy-files.js.to-output.required">
-    <xslt style="${style}" in="${in}" out="${output.dir}/${jspath}/${out}"/>
+    <xslt style="${style}" in="${in}" out="${dita.output.dir}/${jspath}/${out}"/>
   </target>
 
 </project>

--- a/com.moldflow.dita.plus-allhtml-svgobject/insert-ant-topic-html-xslt.xml
+++ b/com.moldflow.dita.plus-allhtml-svgobject/insert-ant-topic-html-xslt.xml
@@ -1,10 +1,11 @@
-<xslt>
+<xslt xmlns:if="ant:if"
+      xmlns:unless="ant:unless">
 
       <!-- SVG-object parameters. -->
-      <param name="plus-svgobject-format" expression="${plus.svgobject.format}" if="plus.svgobject.format"/>
-      <param name="plus-svgobject-raster-mimetype" expression="${plus.svgobject.raster.mimetype}" if="plus.svgobject.raster.mimetype"/>
-      <param name="plus-svgobject-object-convert-to-path" expression="${plus.svgobject.object.convert-to-path}" if="plus.svgobject.object.convert-to-path"/>
-      <param name="plus-svgobject-raster-imagemap" expression="${plus.svgobject.raster.imagemap}" if="plus.svgobject.raster.imagemap"/>
-      <param name="plus-svgobject-path" expression="${plus.svgobject.path}" if="plus.svgobject.path"/>
+      <param name="plus-svgobject-format" expression="${plus.svgobject.format}" if:set="plus.svgobject.format"/>
+      <param name="plus-svgobject-raster-mimetype" expression="${plus.svgobject.raster.mimetype}" if:set="plus.svgobject.raster.mimetype"/>
+      <param name="plus-svgobject-object-convert-to-path" expression="${plus.svgobject.object.convert-to-path}" if:set="plus.svgobject.object.convert-to-path"/>
+      <param name="plus-svgobject-raster-imagemap" expression="${plus.svgobject.raster.imagemap}" if:set="plus.svgobject.raster.imagemap"/>
+      <param name="plus-svgobject-path" expression="${plus.svgobject.path}" if:set="plus.svgobject.path"/>
 
 </xslt>

--- a/com.moldflow.dita.plus-allhtml-syntaxdiagram-svgobject/insert-ant-topic-html-xslt.xml
+++ b/com.moldflow.dita.plus-allhtml-syntaxdiagram-svgobject/insert-ant-topic-html-xslt.xml
@@ -1,8 +1,8 @@
-<xslt>
+<xslt xmlns:if="ant:if"
+      xmlns:unless="ant:unless">
 
       <!-- Syntax Diagram parameters. -->
-      <param name="plus-allhtml-syntaxdiagram-svgobject-csspath" expression="${plus-allhtml-syntaxdiagram-svgobject.csspath}" if="plus-allhtml-syntaxdiagram-svgobject.csspath"/>
-      <param name="plus-allhtml-syntaxdiagram-svgobject-jspath" expression="${plus-allhtml-syntaxdiagram-svgobject.jspath}" if="plus-allhtml-syntaxdiagram-svgobject.jspath"/>
-
+      <param name="plus-allhtml-syntaxdiagram-svgobject-csspath" expression="${plus-allhtml-syntaxdiagram-svgobject.csspath}" if:set="plus-allhtml-syntaxdiagram-svgobject.csspath"/>
+      <param name="plus-allhtml-syntaxdiagram-svgobject-jspath" expression="${plus-allhtml-syntaxdiagram-svgobject.jspath}" if:set="plus-allhtml-syntaxdiagram-svgobject.jspath"/>
 
 </xslt>

--- a/com.moldflow.dita.plus-allhtml-syntaxdiagram/insert-ant-topic-html-xslt.xml
+++ b/com.moldflow.dita.plus-allhtml-syntaxdiagram/insert-ant-topic-html-xslt.xml
@@ -1,7 +1,7 @@
-<xslt>
+<xslt xmlns:if="ant:if"
+      xmlns:unless="ant:unless">
 
       <!-- Syntax Diagram parameters. -->
-      <param name="plus-syntaxdiagram-format" expression="${plus.syntaxdiagram.format}" if="plus.syntaxdiagram.format"/>
-
+      <param name="plus-syntaxdiagram-format" expression="${plus.syntaxdiagram.format}" if:set="plus.syntaxdiagram.format"/>
 
 </xslt>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

* Replace all uses of `if="property` with Ant's namespaced `ant:if="property"` (old version now throws warnings)
* Update to use `<ditafileset>` to pass in list of files for processing, rather than obsolete file lists
* Output all files to `dita.output.dir` (which we set to a temp dir) rather than directly to final output dir