### PR TITLE
Fix groupcomp spacing, improve debugging

### DIFF
--- a/com.ibm.ditatools.svg-diagrams/xsl/stage1-svgobject-ddita.xsl
+++ b/com.ibm.ditatools.svg-diagrams/xsl/stage1-svgobject-ddita.xsl
@@ -114,8 +114,11 @@
     </xsl:result-document>
     
     <xsl:variable name="image-element">
-      <desc class="- topic/desc "><image class="- topic/image " outputclass="generated-diagram">
-        <xsl:attribute name="href">
+      <desc class="- topic/desc ">
+        <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
+        <image class="- topic/image " outputclass="generated-diagram">
+          <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
+          <xsl:attribute name="href">
           <xsl:value-of
             select="concat($plus-svgobject-path, '/', $external-svg-name)"/>
           <!-- For now ... how about we just use SVG file name? If we can't handle it as <object> do it as <image>.
@@ -154,6 +157,7 @@
     <xsl:choose>
       <xsl:when test="$plus-svgobject-format='object'">
         <figgroup class="- topic/figgroup " outputclass="span">
+          <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
           <xsl:if test="$baseline-shift = 'yes'">
             <xsl:attribute name="svgobject:baseline-shift">
               <xsl:value-of
@@ -161,6 +165,9 @@
             </xsl:attribute>
           </xsl:if>
           <object class="- topic/object " outputclass="generated-diagram">
+            <!-- Scale is not usually allowed on object; expect it to be ignored unless code is written to catch it. -->
+            <xsl:copy-of select="ancestor-or-self::*[contains(@class,' pr-d/syntaxdiagram ')]/@scale"/>
+            <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
             <!-- Leave placeholders for width/height to fix up in later pipeline stage,
                             perhaps after JavaScript has resized the SVG's bounding box. -->
             <xsl:attribute name="svgobject:width"></xsl:attribute>
@@ -185,13 +192,18 @@
             <xsl:attribute name="type">image/svg+xml</xsl:attribute>
             <!--<xsl:copy-of select="$image-element"/>-->
             <xsl:if test="not(empty($textversion))">
-              <desc class="- topic/desc "><codeblock class="+ topic/pre pr-d/codeblock "><xsl:copy-of select="$textversion"/></codeblock></desc>
+              <desc class="- topic/desc ">
+                <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
+                <codeblock class="+ topic/pre pr-d/codeblock ">
+                  <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
+                  <xsl:copy-of select="$textversion"/></codeblock></desc>
             </xsl:if>
           </object>
         </figgroup>
       </xsl:when>
       <xsl:when test="$plus-svgobject-format='raster'">
         <figgroup class="- topic/figgroup " outputclass="span">
+          <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
           <xsl:if test="$baseline-shift = 'yes'">
             <xsl:attribute name="svgobject:baseline-shift">
               <xsl:value-of

--- a/com.ibm.ditatools.svg-diagrams/xsl/syntax-svgobject-ddita.xsl
+++ b/com.ibm.ditatools.svg-diagrams/xsl/syntax-svgobject-ddita.xsl
@@ -52,7 +52,9 @@
                     <wrapper><xsl:apply-templates mode="collect-synnotes"/></wrapper>
                 </xsl:variable>
                 <figgroup class="- topic/figgroup ">
+                    <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
                     <title class="- topic/title ">
+                        <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
                         <xsl:call-template name="getVariable">
                             <xsl:with-param name="id" select="'Notes'"/>
                         </xsl:call-template>
@@ -60,7 +62,9 @@
                             <xsl:with-param name="id" select="'ColonSymbol'"/>
                         </xsl:call-template>
                     </title>
-                    <sl class="- topic/sl "><xsl:apply-templates select="$collectnotes" mode="synnote-list"/></sl>
+                    <sl class="- topic/sl ">
+                        <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
+                        <xsl:apply-templates select="$collectnotes" mode="synnote-list"/></sl>
                 </figgroup>
             </xsl:if>
         </fig>
@@ -86,6 +90,7 @@
     
     <xsl:template match="*[contains(@class,' pr-d/synnote ')]" mode="synnote-list">
         <sli class="- topic/sli ">
+            <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
             <xsl:choose>
                 <xsl:when test="@callout"><sup class="+ topic/ph hi-d/sup "><xsl:value-of select="@callout"/></sup></xsl:when>
                 <!-- Originally used position() instead of count(). Resulted in double count, first note was 2, second was 4. --> 
@@ -98,6 +103,7 @@
 
     <xsl:template match="*[contains(@class, &apos; pr-d/synblk &apos;)]" mode="syntaxdiagram-svgobject:default">
         <figgroup class="- topic/figgroup " outputclass="synblk">
+            <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
             <!--<xsl:attribute name="class">synblk</xsl:attribute>
             <xsl:call-template name="commonattributes"></xsl:call-template>
             <xsl:call-template name="setidaname"></xsl:call-template>
@@ -108,6 +114,7 @@
 
     <xsl:template match="*[contains(@class, &apos; pr-d/fragment &apos;)]" mode="syntaxdiagram-svgobject:default">
         <figgroup class="- topic/figgroup " outputclass="fragment">
+            <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
             <!--<xsl:attribute name="class">fragment</xsl:attribute>
             <xsl:call-template name="commonattributes"></xsl:call-template>
             <xsl:call-template name="setidaname"></xsl:call-template>
@@ -127,6 +134,7 @@
                 <xsl:when test="count(preceding-sibling::*) = 0 or                     preceding-sibling::*[1][                     contains(@class, &apos; topic/title &apos;)                     or contains(@class, &apos; pr-d/syntaxdiagram &apos;)                     or contains(@class, &apos; pr-d/synblk &apos;)                     or contains(@class, &apos; pr-d/fragment &apos;)]">
                     <!-- Other elements start a syntax diagram. -->
                     <figgroup class="- topic/figgroup " outputclass="syntaxdiagram-piece">
+                        <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
                         <xsl:variable name="syntax-pieces" as="element()">
                             <!-- Collects pieces that will be in this fragment, for evaluation in accessible portion -->
                             <wrapper><xsl:apply-templates select="." mode="syntaxdiagram2svg:collect-for-a11y"/></wrapper>
@@ -318,6 +326,7 @@
     <!-- Title for syntaxdiagram. -->
     <xsl:template match="*[contains(@class, &apos; pr-d/syntaxdiagram &apos;)]/*[contains(@class, &apos; topic/title &apos;)]" mode="syntaxdiagram-svgobject:default">
         <title class="- topic/title " outputclass="syntaxdiagram-title">
+            <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
             <!--<xsl:attribute name="class">syntaxdiagram-title</xsl:attribute>
             <xsl:call-template name="commonattributes"></xsl:call-template>
             <xsl:call-template name="setidaname"></xsl:call-template>
@@ -329,6 +338,7 @@
     <!-- Title for synblk. -->
     <xsl:template match="*[contains(@class, &apos; pr-d/synblk &apos;)]/*[contains(@class, &apos; topic/title &apos;)]" mode="syntaxdiagram-svgobject:default">
         <title class="- topic/title " outputclass="synblk-title">
+            <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
             <!--<xsl:attribute name="class">synblk-title</xsl:attribute>
             <xsl:call-template name="commonattributes"></xsl:call-template>
             <xsl:call-template name="setidaname"></xsl:call-template>
@@ -340,6 +350,7 @@
     <!-- Title for fragment. -->
     <xsl:template match="*[contains(@class, &apos; pr-d/fragment &apos;)]/*[contains(@class, &apos; topic/title &apos;)]" mode="syntaxdiagram-svgobject:default">
         <title class="- topic/title " outputclass="fragment-title">
+            <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
             <!--<xsl:attribute name="class">fragment-title</xsl:attribute>
             <xsl:call-template name="commonattributes"></xsl:call-template>
             <xsl:call-template name="setidaname"></xsl:call-template>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Fixes several issues with spacing around titled group elements.

Also passes along the `@xtrc` and `@xtrf` debug attributes, so that later steps can still trace back to original markup; some extensions using this code crashed due to missing debug info.