### PR TITLE
Fix broken syntax link when using uplevels

### DIFF
--- a/com.ibm.ditatools.svg-diagrams/xsl/stage1-ddita.xsl
+++ b/com.ibm.ditatools.svg-diagrams/xsl/stage1-ddita.xsl
@@ -3,7 +3,8 @@
     
 <xsl:param name="OUTEXT"></xsl:param>
 <xsl:param name="PATH2PROJ">
-<xsl:apply-templates select="/processing-instruction('path2project')[1]" mode="get-path2project"/>
+  <!-- Diagrams are all generated in svgobject/ relative to map, so we actually want path to map to fix the path from here to svgobject/ -->
+  <xsl:value-of select="/processing-instruction()[name()='path2rootmap-uri'][1]"/>
 </xsl:param>
 <xsl:param name="msgprefix">meep</xsl:param>
 


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Fixes an issue where all diagrams were dropped if the map used "up levels" linking, to any files outside of the map directory.