### PR TITLE
Add ability to link to external file for accessible / readable version

### DIFF
--- a/com.ibm.ditatools.svg-diagrams/xsl/stage1-svgobject-ddita.xsl
+++ b/com.ibm.ditatools.svg-diagrams/xsl/stage1-svgobject-ddita.xsl
@@ -3,7 +3,7 @@
   xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:svgobject="http://www.moldflow.com/namespace/2008/dita/svgobject"
   xmlns:hash="com.moldflow.xslt.hash"
-  xmlns:dcs="com.ibm.ditatools.dcs"
+  xmlns:dcs="http://rtpdoc01.rtp.raleigh.ibm.com:9082/kc/dcs"
   exclude-result-prefixes="hash">
   
   <xsl:param name="plus-svgobject-format" select="'object'"/>
@@ -189,6 +189,13 @@
             </xsl:attribute>
             <xsl:attribute name="dcs:alt"><xsl:value-of select="$alt"/></xsl:attribute>
             <xsl:attribute name="dcs:object">syntaxdiagram</xsl:attribute>
+            <xsl:attribute name="dcs:accessible">
+              <xsl:value-of select="if (contains($FILENAME,'.dita'))
+                then (substring-before($FILENAME,'.dita'))
+                else ($FILENAME)"/>
+              <xsl:text>_syn</xsl:text>
+              <xsl:value-of select="generate-id(.)"/>
+            </xsl:attribute>
             <xsl:attribute name="type">image/svg+xml</xsl:attribute>
             <!--<xsl:copy-of select="$image-element"/>-->
             <xsl:if test="not(empty($textversion))">

--- a/com.ibm.ditatools.svg-diagrams/xsl/syntax-svgobject-ddita.xsl
+++ b/com.ibm.ditatools.svg-diagrams/xsl/syntax-svgobject-ddita.xsl
@@ -5,7 +5,8 @@
     xmlns:syntaxdiagram-svgobject="http://www.moldflow.com/namespace/2008/plus-allhtml-syntaxdiagram-svgobject" 
     xmlns:svgobject="http://www.moldflow.com/namespace/2008/dita/svgobject" 
     xmlns:syntaxdiagram2svg="http://www.moldflow.com/namespace/2008/syntaxdiagram2svg" 
-    exclude-result-prefixes="syntaxdiagram-svgobject syntaxdiagram2svg xs">
+    xmlns:dcs="http://rtpdoc01.rtp.raleigh.ibm.com:9082/kc/dcs"
+    exclude-result-prefixes="syntaxdiagram-svgobject syntaxdiagram2svg xs dcs">
 
     
 <xsl:import href="plugin:com.moldflow.dita.syntaxdiagram2svg:xsl/syntaxdiagram2svg.xsl"/>
@@ -40,7 +41,7 @@
 
     <!-- Top-level syntax diagram elements. -->
     <xsl:template match="*[contains(@class, &apos; pr-d/syntaxdiagram &apos;)]" mode="syntaxdiagram-svgobject:default">
-        <fig>
+        <fig dcs:outputclass="syntaxdiagram">
             <xsl:copy-of select="@*"/>
             <xsl:attribute name="class">- topic/fig </xsl:attribute>
             <!--<xsl:call-template name="commonattributes"></xsl:call-template>
@@ -221,7 +222,7 @@
             <xsl:with-param name="prefix" select="$prefix" as="xs:string"/>
             <xsl:with-param name="grouplevel" select="$grouplevel"/>
           </xsl:apply-templates>
-          </xsl:if>
+        </xsl:if>
     </xsl:template>
     
     <xsl:template match="*[contains(@class,' pr-d/groupcomp ')]" mode="syntaxdiagram2svg:create-accessible-version">
@@ -233,7 +234,7 @@
             <xsl:with-param name="grouplevel" select="$grouplevel"/>
         </xsl:apply-templates>
         <xsl:if test="parent::wrapper">
-            <xsl:apply-templates select="following-sibling::*[1]" mode="syntaxdiagram2svg:create-accessible-version">
+          <xsl:apply-templates select="following-sibling::*[1]" mode="syntaxdiagram2svg:create-accessible-version">
               <xsl:with-param name="prefix" select="$prefix" as="xs:string"/>
               <xsl:with-param name="grouplevel" select="$grouplevel"/>
           </xsl:apply-templates>
@@ -248,7 +249,7 @@
             <xsl:with-param name="grouplevel" select="$grouplevel"/>
         </xsl:apply-templates>
         <xsl:if test="parent::wrapper">
-            <xsl:apply-templates select="following-sibling::*[1]" mode="syntaxdiagram2svg:create-accessible-version">
+          <xsl:apply-templates select="following-sibling::*[1]" mode="syntaxdiagram2svg:create-accessible-version">
               <xsl:with-param name="prefix" select="$prefix" as="xs:string"/>
               <xsl:with-param name="grouplevel" select="$grouplevel"/>
           </xsl:apply-templates>

--- a/com.moldflow.dita.plus-allhtml-syntaxdiagram-svgobject/xsl/ddita.xsl
+++ b/com.moldflow.dita.plus-allhtml-syntaxdiagram-svgobject/xsl/ddita.xsl
@@ -42,6 +42,7 @@
 
     <xsl:template match="*[contains(@class, &apos; pr-d/synblk &apos;)]" mode="syntaxdiagram-svgobject:default">
         <figgroup class="- topic/figgroup " outputclass="synblk">
+            <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
             <!--<xsl:attribute name="class">synblk</xsl:attribute>
             <xsl:call-template name="commonattributes"></xsl:call-template>
             <xsl:call-template name="setidaname"></xsl:call-template>
@@ -52,6 +53,7 @@
 
     <xsl:template match="*[contains(@class, &apos; pr-d/fragment &apos;)]" mode="syntaxdiagram-svgobject:default">
         <figgroup class="- topic/figgroup " outputclass="fragment">
+            <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
             <!--<xsl:attribute name="class">fragment</xsl:attribute>
             <xsl:call-template name="commonattributes"></xsl:call-template>
             <xsl:call-template name="setidaname"></xsl:call-template>
@@ -71,6 +73,7 @@
                 <xsl:when test="count(preceding-sibling::*) = 0 or                     preceding-sibling::*[1][                     contains(@class, &apos; topic/title &apos;)                     or contains(@class, &apos; pr-d/syntaxdiagram &apos;)                     or contains(@class, &apos; pr-d/synblk &apos;)                     or contains(@class, &apos; pr-d/fragment &apos;)]">
                     <!-- Other elements start a syntax diagram. -->
                     <figgroup class="- topic/figgroup " outputclass="syntaxdiagram-piece">
+                        <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
                         <!--<xsl:attribute name="class">syntaxdiagram-piece</xsl:attribute>-->
 
                         <xsl:apply-templates select="." mode="svgobject:generate-reference">
@@ -103,6 +106,7 @@
     <!-- Title for syntaxdiagram. -->
     <xsl:template match="*[contains(@class, &apos; pr-d/syntaxdiagram &apos;)]/*[contains(@class, &apos; topic/title &apos;)]" mode="syntaxdiagram-svgobject:default">
         <title class="- topic/title " outputclass="syntaxdiagram-title">
+            <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
             <!--<xsl:attribute name="class">syntaxdiagram-title</xsl:attribute>
             <xsl:call-template name="commonattributes"></xsl:call-template>
             <xsl:call-template name="setidaname"></xsl:call-template>
@@ -114,6 +118,7 @@
     <!-- Title for synblk. -->
     <xsl:template match="*[contains(@class, &apos; pr-d/synblk &apos;)]/*[contains(@class, &apos; topic/title &apos;)]" mode="syntaxdiagram-svgobject:default">
         <title class="- topic/title " outputclass="synblk-title">
+            <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
             <!--<xsl:attribute name="class">synblk-title</xsl:attribute>
             <xsl:call-template name="commonattributes"></xsl:call-template>
             <xsl:call-template name="setidaname"></xsl:call-template>
@@ -125,6 +130,7 @@
     <!-- Title for fragment. -->
     <xsl:template match="*[contains(@class, &apos; pr-d/fragment &apos;)]/*[contains(@class, &apos; topic/title &apos;)]" mode="syntaxdiagram-svgobject:default">
         <title class="- topic/title " outputclass="fragment-title">
+            <xsl:copy-of select="ancestor-or-self::*[@xtrf][1]/@xtrf | ancestor-or-self::*[@xtrc][1]/@xtrc"/>
             <!--<xsl:attribute name="class">fragment-title</xsl:attribute>
             <xsl:call-template name="commonattributes"></xsl:call-template>
             <xsl:call-template name="setidaname"></xsl:call-template>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Adds a hook that can be used to generate individual HTML files, with readable version of the diagram.

Also integrates several additional updates to ensure we preserve `@xtrf` and `@xtrc`.