### PR TITLE
Selectively hide boxes and arrows

### DIFF
--- a/com.moldflow.dita.syntaxdiagram2svg/js/boxed.js
+++ b/com.moldflow.dita.syntaxdiagram2svg/js/boxed.js
@@ -41,6 +41,7 @@ function syntaxdiagram_boxed_init(g)
   box.setAttribute("width", runningWidth + 2 * syntaxdiagram_Constants.box_padding_horizontal);
   box.setAttribute("height", maxHeightAbove + maxHeightBelow + 2 * syntaxdiagram_Constants.box_padding_vertical);
   box.setAttribute("rx", syntaxdiagram_Constants.box_corner_radius[g.getAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "element")]);
+  box.setAttribute("class", "syntax" + g.getAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "element"));
   g.appendChild(box);
 
   g.setAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "syntaxdiagram2svg:width", runningWidth + 2 * syntaxdiagram_Constants.box_padding_horizontal);

--- a/com.moldflow.dita.syntaxdiagram2svg/js/decision.js
+++ b/com.moldflow.dita.syntaxdiagram2svg/js/decision.js
@@ -45,7 +45,8 @@ function syntaxdiagram_decision_init(g)
     g.appendChild(initialLine);
     if (straightClass != 'void')  // Otherwise arrow density is a bit much.
     {
-      g.appendChild(syntaxdiagram_arrowHead(runningWidth, 0, 0));
+      //into main line box in choice group, possibly others
+      g.appendChild(syntaxdiagram_arrowHeadAnnotated(runningWidth, 0, 0, "StartChoice"));
     }
     syntaxdiagram_Dispatch[straightClass]["place"](straight, runningWidth,0);
     runningWidth = runningWidth + straightWidth;
@@ -57,7 +58,8 @@ function syntaxdiagram_decision_init(g)
     finalLine.setAttribute("x2", runningWidth);
     finalLine.setAttribute("y2", 0);
     g.appendChild(finalLine);
-    g.appendChild(syntaxdiagram_arrowHead(runningWidth - syntaxdiagram_Constants.decision_corner_radius, 0, 0));
+    //Coming out of main line choice group, as choices come back together
+    g.appendChild(syntaxdiagram_arrowHeadAnnotated(runningWidth - syntaxdiagram_Constants.decision_corner_radius, 0, 0, "AfterChoice"));
   }
 
   // Lines above centre.
@@ -89,8 +91,9 @@ function syntaxdiagram_decision_init(g)
           "Q" + (syntaxdiagram_Constants.decision_corner_radius) + " " + (0 - newRunningHeightAbove) + " " + (syntaxdiagram_Constants.decision_corner_radius * 2) + " "+ (0 - newRunningHeightAbove) + " " + 
           "L" + (2 * syntaxdiagram_Constants.decision_corner_radius + syntaxdiagram_Constants.decision_join_length_initial + (maxWidth/2) - (upwardWidth/2)) + " " + (0 - newRunningHeightAbove)
         );
-      g.appendChild(initialLine);    
-      g.appendChild(syntaxdiagram_arrowHead(2 * syntaxdiagram_Constants.decision_corner_radius + syntaxdiagram_Constants.decision_join_length_initial + (maxWidth/2) - (upwardWidth/2), 0 - newRunningHeightAbove, 0));
+      g.appendChild(initialLine);
+      //Arrow entering above-the-line default in choice group
+      g.appendChild(syntaxdiagram_arrowHeadAnnotated(2 * syntaxdiagram_Constants.decision_corner_radius + syntaxdiagram_Constants.decision_join_length_initial + (maxWidth/2) - (upwardWidth/2), 0 - newRunningHeightAbove, 0, "StartChoice"));
       
       syntaxdiagram_Dispatch[upwardClass]["place"](upwardList[i], 2 * syntaxdiagram_Constants.decision_corner_radius + syntaxdiagram_Constants.decision_join_length_initial + (maxWidth/2) - (upwardWidth/2), 0 - newRunningHeightAbove);
       
@@ -103,8 +106,9 @@ function syntaxdiagram_decision_init(g)
           "L" + (3 * syntaxdiagram_Constants.decision_corner_radius + syntaxdiagram_Constants.decision_join_length_final + syntaxdiagram_Constants.decision_join_length_initial + maxWidth) + " " + (0 - syntaxdiagram_Constants.decision_corner_radius) + " " + 
           "Q" + (3 * syntaxdiagram_Constants.decision_corner_radius + syntaxdiagram_Constants.decision_join_length_final + syntaxdiagram_Constants.decision_join_length_initial + maxWidth) + " " + (0) + " " + (4 * syntaxdiagram_Constants.decision_corner_radius + syntaxdiagram_Constants.decision_join_length_final + syntaxdiagram_Constants.decision_join_length_initial + maxWidth) + " "+ (0)
         );
-      g.appendChild(finalLine);    
-      g.appendChild(syntaxdiagram_arrowHead(3 * syntaxdiagram_Constants.decision_corner_radius + syntaxdiagram_Constants.decision_join_length_final + syntaxdiagram_Constants.decision_join_length_initial + maxWidth, 0 - syntaxdiagram_Constants.decision_corner_radius, 90));
+      g.appendChild(finalLine);
+      //Arrow pointind down, returning above-the-line default back to main line
+      g.appendChild(syntaxdiagram_arrowHeadAnnotated(3 * syntaxdiagram_Constants.decision_corner_radius + syntaxdiagram_Constants.decision_join_length_final + syntaxdiagram_Constants.decision_join_length_initial + maxWidth, 0 - syntaxdiagram_Constants.decision_corner_radius, 90, "AfterChoice"));
       
       runningHeightAbove = newRunningHeightAbove;
       maxHeightAbove = runningHeightAbove + upwardHeightAbove;
@@ -140,8 +144,9 @@ function syntaxdiagram_decision_init(g)
           "Q" + (syntaxdiagram_Constants.decision_corner_radius) + " " + (newRunningHeightBelow) + " " + (syntaxdiagram_Constants.decision_corner_radius * 2) + " "+ (newRunningHeightBelow) + " " + 
           "L" + (2 * syntaxdiagram_Constants.decision_corner_radius + syntaxdiagram_Constants.decision_join_length_initial + (maxWidth/2) - (downwardWidth/2)) + " " + (newRunningHeightBelow)
         );
-      g.appendChild(initialLine);    
-      g.appendChild(syntaxdiagram_arrowHead(2 * syntaxdiagram_Constants.decision_corner_radius + syntaxdiagram_Constants.decision_join_length_initial + (maxWidth/2) - (downwardWidth/2), newRunningHeightBelow, 0));
+      g.appendChild(initialLine);
+      //Entering a choice below the main line in a choice group, maybe others
+      g.appendChild(syntaxdiagram_arrowHeadAnnotated(2 * syntaxdiagram_Constants.decision_corner_radius + syntaxdiagram_Constants.decision_join_length_initial + (maxWidth/2) - (downwardWidth/2), newRunningHeightBelow, 0, "StartChoice"));
       
       syntaxdiagram_Dispatch[downwardClass]["place"](downwardList[i], 2 * syntaxdiagram_Constants.decision_corner_radius + syntaxdiagram_Constants.decision_join_length_initial + (maxWidth/2) - (downwardWidth/2), newRunningHeightBelow);
       
@@ -154,8 +159,9 @@ function syntaxdiagram_decision_init(g)
           "L" + (3 * syntaxdiagram_Constants.decision_corner_radius + syntaxdiagram_Constants.decision_join_length_final + syntaxdiagram_Constants.decision_join_length_initial + maxWidth) + " " + (syntaxdiagram_Constants.decision_corner_radius) + " " + 
           "Q" + (3 * syntaxdiagram_Constants.decision_corner_radius + syntaxdiagram_Constants.decision_join_length_final + syntaxdiagram_Constants.decision_join_length_initial + maxWidth) + " " + (0) + " " + (4 * syntaxdiagram_Constants.decision_corner_radius + syntaxdiagram_Constants.decision_join_length_final + syntaxdiagram_Constants.decision_join_length_initial + maxWidth) + " "+ (0)
         );
-      g.appendChild(finalLine);    
-      g.appendChild(syntaxdiagram_arrowHead(3 * syntaxdiagram_Constants.decision_corner_radius + syntaxdiagram_Constants.decision_join_length_final + syntaxdiagram_Constants.decision_join_length_initial + maxWidth, syntaxdiagram_Constants.decision_corner_radius, -90));
+      g.appendChild(finalLine); 
+      //Below-the-line choices in choice group, arrow points up on line joining each choice back into main line
+      g.appendChild(syntaxdiagram_arrowHeadAnnotated(3 * syntaxdiagram_Constants.decision_corner_radius + syntaxdiagram_Constants.decision_join_length_final + syntaxdiagram_Constants.decision_join_length_initial + maxWidth, syntaxdiagram_Constants.decision_corner_radius, -90, "AfterChoice"));
       
       runningHeightBelow = newRunningHeightBelow;
       maxHeightBelow = runningHeightBelow + downwardHeightBelow;

--- a/com.moldflow.dita.syntaxdiagram2svg/js/diagram.js
+++ b/com.moldflow.dita.syntaxdiagram2svg/js/diagram.js
@@ -73,9 +73,9 @@ function syntaxdiagram_diagram_init(g)
   
   var runningWidth = 0;
   
-  // Initial arrow.
-  g.appendChild(syntaxdiagram_arrowHead(0, overallHeight, 0));
-  g.appendChild(syntaxdiagram_arrowHead(syntaxdiagram_Constants.arrow_size, overallHeight, 0));
+  // Initial arrows.
+  g.appendChild(syntaxdiagram_arrowHeadAnnotated(0, overallHeight, 0, "StartEnd"));
+  g.appendChild(syntaxdiagram_arrowHeadAnnotated(syntaxdiagram_Constants.arrow_size, overallHeight, 0,"StartEnd"));
   var initialLine = document.createElementNS("http://www.w3.org/2000/svg", "line");
   initialLine.setAttribute("class", "arrow");
   initialLine.setAttribute("x1", 0);
@@ -93,12 +93,18 @@ function syntaxdiagram_diagram_init(g)
 
     var rowNumber = children[i].getAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "row");
     
+    var nextRowNumber = 0;
+    if (i != children.length - 1) {
+        nextRowNumber = children[i+1].getAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "row");
+    }
+    
     if (rowNumber != lastRowNumber)
     {
       runningWidth = syntaxdiagram_Constants.diagram_wrap_indent;
       overallHeight = overallHeight + heightBelow[lastRowNumber] + heightAbove[rowNumber] + syntaxdiagram_Constants.diagram_row_padding;
 
-      g.appendChild(syntaxdiagram_arrowHead(runningWidth, overallHeight, 0));
+      //Start new block of diagram, indented, after previous block
+      g.appendChild(syntaxdiagram_arrowHeadAnnotated(runningWidth, overallHeight, 0,"StartEnd"));
       var medialLine = document.createElementNS("http://www.w3.org/2000/svg", "line");
       medialLine.setAttribute("class", "arrow");
       medialLine.setAttribute("x1", runningWidth);
@@ -123,13 +129,19 @@ function syntaxdiagram_diagram_init(g)
       medialLine.setAttribute("x2", runningWidth);
       medialLine.setAttribute("y2", overallHeight);
       g.appendChild(medialLine);
-      g.appendChild(syntaxdiagram_arrowHead(runningWidth, overallHeight, 0));
+      //Arrow signaling to ontinue to next main child of diagram.
+      //If last item before a line break to next set of groups, use StartEnd, otherwise Seq.
+      if (rowNumber != nextRowNumber) {
+          g.appendChild(syntaxdiagram_arrowHeadAnnotated(runningWidth, overallHeight, 0,"StartEnd"));
+      } else {
+          g.appendChild(syntaxdiagram_arrowHeadAnnotated(runningWidth, overallHeight, 0,"Seq"));
+      }
+      
     }
 
     lastRowNumber = rowNumber;
   }
-  
-  // Final arrow.
+    
   var finalLine = document.createElementNS("http://www.w3.org/2000/svg", "line");
   finalLine.setAttribute("class", "arrow");
   finalLine.setAttribute("x1", runningWidth);
@@ -138,8 +150,9 @@ function syntaxdiagram_diagram_init(g)
   finalLine.setAttribute("x2", runningWidth);
   finalLine.setAttribute("y2", overallHeight);
   g.appendChild(finalLine);
-  g.appendChild(syntaxdiagram_arrowHead(runningWidth, overallHeight, 0));
-  g.appendChild(syntaxdiagram_arrowHead(runningWidth, overallHeight, 180));
+  // Final arrows.
+  g.appendChild(syntaxdiagram_arrowHeadAnnotated(runningWidth, overallHeight, 0,"StartEnd"));
+  g.appendChild(syntaxdiagram_arrowHeadAnnotated(runningWidth, overallHeight, 180,"StartEnd"));
 
   g.setAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "syntaxdiagram2svg:width", maxWidth + 2 * syntaxdiagram_Constants.diagram_margin_sides);
   g.setAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "syntaxdiagram2svg:heightAbove", 0 + syntaxdiagram_Constants.diagram_margin_topbottom);

--- a/com.moldflow.dita.syntaxdiagram2svg/js/loop.js
+++ b/com.moldflow.dita.syntaxdiagram2svg/js/loop.js
@@ -55,7 +55,8 @@ function syntaxdiagram_loop_init(g)
   initialLine.setAttribute("x2", runningWidth);
   initialLine.setAttribute("y2", 0);
   g.appendChild(initialLine);
-  g.appendChild(syntaxdiagram_arrowHead(runningWidth, 0, 0));
+  //Re-entering a looped box, first item in repeated group, maybe others
+  g.appendChild(syntaxdiagram_arrowHeadAnnotated(runningWidth, 0, 0,"StartRepGroup"));
   
   if (children.length == 1)
   {
@@ -71,7 +72,8 @@ function syntaxdiagram_loop_init(g)
   finalLine.setAttribute("x2", runningWidth);
   finalLine.setAttribute("y2", 0);
   g.appendChild(finalLine);
-  g.appendChild(syntaxdiagram_arrowHead(runningWidth - syntaxdiagram_Constants.loop_corner_radius, 0, 0));
+  //End of repeated group, arrow just before the line up to repeat
+  g.appendChild(syntaxdiagram_arrowHeadAnnotated(runningWidth - syntaxdiagram_Constants.loop_corner_radius, 0, 0,"EndRepGroup"));
 
   g.setAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "syntaxdiagram2svg:width", runningWidth);
   
@@ -88,7 +90,7 @@ function syntaxdiagram_loop_init(g)
     );
   g.appendChild(initialReturnLine);
   runningWidth = runningWidth - syntaxdiagram_Constants.loop_corner_radius - syntaxdiagram_Constants.loop_join_length_final - maxWidth/2 + repsepWidth/2;
-  g.appendChild(syntaxdiagram_arrowHead(runningWidth, 0 - returnHeightAbove, 180));
+  g.appendChild(syntaxdiagram_arrowHeadAnnotated(runningWidth, 0 - returnHeightAbove, 180,"RepSep"));
   
   runningWidth = runningWidth - repsepWidth;
   
@@ -116,7 +118,7 @@ function syntaxdiagram_loop_init(g)
   //    (0) + "," + (0)
   //  );
   //g.appendChild(finalReturnLine);
-  g.appendChild(syntaxdiagram_arrowHead(0, 0 - syntaxdiagram_Constants.loop_corner_radius, 90));
+  g.appendChild(syntaxdiagram_arrowHeadAnnotated(0, 0 - syntaxdiagram_Constants.loop_corner_radius, 90,"RepSepReturn"));
   
   g.setAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "syntaxdiagram2svg:heightAbove", childHeightAbove + syntaxdiagram_Constants.loop_row_padding + repsepHeightBelow + repsepHeightAbove);
   g.setAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "syntaxdiagram2svg:heightBelow", childHeightBelow);

--- a/com.moldflow.dita.syntaxdiagram2svg/js/main.js
+++ b/com.moldflow.dita.syntaxdiagram2svg/js/main.js
@@ -97,10 +97,10 @@ function syntaxdiagram_getDispatchableChildren(g, elementName, className)
   return result;
 }
 
-function syntaxdiagram_arrowHead(x, y, angle)
+function syntaxdiagram_arrowHeadAnnotated(x, y, angle, whicharrow)
 {
   var g = document.createElementNS("http://www.w3.org/2000/svg", "polygon");
-  g.setAttribute("class", "arrowhead");
+  g.setAttribute("class", "arrowhead" + whicharrow);
   g.setAttribute("points",
       (x) + "," + (y) + " " +
       (x - syntaxdiagram_Constants.arrow_size) + "," + (y + syntaxdiagram_Constants.arrow_size / 2) + " " +

--- a/com.moldflow.dita.syntaxdiagram2svg/js/revdecision.js
+++ b/com.moldflow.dita.syntaxdiagram2svg/js/revdecision.js
@@ -45,7 +45,7 @@ function syntaxdiagram_revdecision_init(g)
     g.appendChild(initialLine);
     if (straightClass != 'void')
     {
-      g.appendChild(syntaxdiagram_arrowHead(runningWidth, 0, 180));
+      g.appendChild(syntaxdiagram_arrowHeadAnnotated(runningWidth, 0, 180,"Rev"));
     }
     runningWidth = runningWidth - straightWidth;
     syntaxdiagram_Dispatch[straightClass]["place"](straight, runningWidth, 0);
@@ -57,7 +57,7 @@ function syntaxdiagram_revdecision_init(g)
     finalLine.setAttribute("x2", runningWidth);
     finalLine.setAttribute("y2", 0);
     g.appendChild(finalLine);
-    g.appendChild(syntaxdiagram_arrowHead(runningWidth + syntaxdiagram_Constants.decision_corner_radius, 0, 180));
+    g.appendChild(syntaxdiagram_arrowHeadAnnotated(runningWidth + syntaxdiagram_Constants.decision_corner_radius, 0, 180,"Rev"));
   }
 
   // Lines above centre.
@@ -90,7 +90,7 @@ function syntaxdiagram_revdecision_init(g)
           "L" + (0 - 2 * syntaxdiagram_Constants.decision_corner_radius - syntaxdiagram_Constants.decision_join_length_initial - (maxWidth/2) + (upwardWidth/2)) + " " + (0 - newRunningHeightAbove)
         );
       g.appendChild(initialLine);    
-      g.appendChild(syntaxdiagram_arrowHead(0 - 2 * syntaxdiagram_Constants.decision_corner_radius - syntaxdiagram_Constants.decision_join_length_initial - (maxWidth/2) + (upwardWidth/2), 0 - newRunningHeightAbove, 180));
+      g.appendChild(syntaxdiagram_arrowHeadAnnotated(0 - 2 * syntaxdiagram_Constants.decision_corner_radius - syntaxdiagram_Constants.decision_join_length_initial - (maxWidth/2) + (upwardWidth/2), 0 - newRunningHeightAbove, 180, "Rev"));
       
       syntaxdiagram_Dispatch[upwardClass]["place"](upwardList[i], 0 - 2 * syntaxdiagram_Constants.decision_corner_radius - syntaxdiagram_Constants.decision_join_length_initial - (maxWidth/2) - (upwardWidth/2), 0 - newRunningHeightAbove);
       
@@ -104,7 +104,7 @@ function syntaxdiagram_revdecision_init(g)
           "Q" + (0 - 3 * syntaxdiagram_Constants.decision_corner_radius - syntaxdiagram_Constants.decision_join_length_final - syntaxdiagram_Constants.decision_join_length_initial - maxWidth) + " " + (0) + " " + (0 - 4 * syntaxdiagram_Constants.decision_corner_radius - syntaxdiagram_Constants.decision_join_length_final - syntaxdiagram_Constants.decision_join_length_initial - maxWidth) + " "+ (0)
         );
       g.appendChild(finalLine);    
-      g.appendChild(syntaxdiagram_arrowHead(0 - 3 * syntaxdiagram_Constants.decision_corner_radius - syntaxdiagram_Constants.decision_join_length_final - syntaxdiagram_Constants.decision_join_length_initial - maxWidth, 0 - syntaxdiagram_Constants.decision_corner_radius, 90));
+      g.appendChild(syntaxdiagram_arrowHeadAnnotated(0 - 3 * syntaxdiagram_Constants.decision_corner_radius - syntaxdiagram_Constants.decision_join_length_final - syntaxdiagram_Constants.decision_join_length_initial - maxWidth, 0 - syntaxdiagram_Constants.decision_corner_radius, 90, "Rev"));
       
       runningHeightAbove = newRunningHeightAbove;
       maxHeightAbove = runningHeightAbove + upwardHeightAbove;
@@ -141,7 +141,7 @@ function syntaxdiagram_revdecision_init(g)
           "L" + (0 - 2 * syntaxdiagram_Constants.decision_corner_radius - syntaxdiagram_Constants.decision_join_length_initial - (maxWidth/2) + (downwardWidth/2)) + " " + (newRunningHeightBelow)
         );
       g.appendChild(initialLine);    
-      g.appendChild(syntaxdiagram_arrowHead(0 - 2 * syntaxdiagram_Constants.decision_corner_radius - syntaxdiagram_Constants.decision_join_length_initial - (maxWidth/2) + (downwardWidth/2), newRunningHeightBelow, 180));
+      g.appendChild(syntaxdiagram_arrowHeadAnnotated(0 - 2 * syntaxdiagram_Constants.decision_corner_radius - syntaxdiagram_Constants.decision_join_length_initial - (maxWidth/2) + (downwardWidth/2), newRunningHeightBelow, 180,"Rev"));
       
       syntaxdiagram_Dispatch[downwardClass]["place"](downwardList[i], 0 - 2 * syntaxdiagram_Constants.decision_corner_radius - syntaxdiagram_Constants.decision_join_length_initial - (maxWidth/2) - (downwardWidth/2), newRunningHeightBelow);
       
@@ -155,7 +155,7 @@ function syntaxdiagram_revdecision_init(g)
           "Q" + (0 - 3 * syntaxdiagram_Constants.decision_corner_radius - syntaxdiagram_Constants.decision_join_length_final - syntaxdiagram_Constants.decision_join_length_initial - maxWidth) + " " + (0) + " " + (0 - 4 * syntaxdiagram_Constants.decision_corner_radius - syntaxdiagram_Constants.decision_join_length_final - syntaxdiagram_Constants.decision_join_length_initial - maxWidth) + " "+ (0)
         );
       g.appendChild(finalLine);    
-      g.appendChild(syntaxdiagram_arrowHead(0 - 3 * syntaxdiagram_Constants.decision_corner_radius - syntaxdiagram_Constants.decision_join_length_final - syntaxdiagram_Constants.decision_join_length_initial - maxWidth, syntaxdiagram_Constants.decision_corner_radius, -90));
+      g.appendChild(syntaxdiagram_arrowHeadAnnotated(0 - 3 * syntaxdiagram_Constants.decision_corner_radius - syntaxdiagram_Constants.decision_join_length_final - syntaxdiagram_Constants.decision_join_length_initial - maxWidth, syntaxdiagram_Constants.decision_corner_radius, -90, "Rev"));
       
       runningHeightBelow = newRunningHeightBelow;
       maxHeightBelow = runningHeightBelow + downwardHeightBelow;

--- a/com.moldflow.dita.syntaxdiagram2svg/js/sequence.js
+++ b/com.moldflow.dita.syntaxdiagram2svg/js/sequence.js
@@ -39,7 +39,8 @@ function syntaxdiagram_sequence_init(g)
       medialLine.setAttribute("x2", runningWidth);
       medialLine.setAttribute("y2", 0);
       g.appendChild(medialLine);
-      g.appendChild(syntaxdiagram_arrowHead(runningWidth, 0, 0));
+      //Arrow entering box in sequence group
+      g.appendChild(syntaxdiagram_arrowHeadAnnotated(runningWidth, 0, 0,"Seq"));
     }
   }
 

--- a/com.moldflow.dita.syntaxdiagram2svg/js/text.js
+++ b/com.moldflow.dita.syntaxdiagram2svg/js/text.js
@@ -16,19 +16,28 @@ function syntaxdiagram_text_init(g)
   //t.setAttribute("font-family", syntaxdiagram_Constants.font_face);
   //t.setAttribute("font-size", syntaxdiagram_Constants.font_size);
   
-  if (t.hasChildNodes())
+  if (t.hasChildNodes() && t.getBBox() != null)
   {
-    g.setAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "syntaxdiagram2svg:width", t.getBBox().width);
+    //Original purpose for @textLength: tell this text how long it was, in case it is being rendered later with a different renderer.
+    //Caused problems for some strings; resulted in squashed text for short strings with leading spaces or punctuation.
+    //Does not appear necessary for recent HTML or PDF support.
+    //syntaxdiagram2svg:width is still needed to set box width and calculate space to leave between lines.
+    if (t.getAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "extendwidth") != '') {
+        //Lead space and a few other leading characters cause slightly squashed text, allow a bit extra width.
+        //t.setAttribute("textLength", (4 + t.getBBox().width));
+        g.setAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "syntaxdiagram2svg:width", (Number(t.getAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "extendwidth")) + (t.getBBox().width * syntaxdiagram_Constants.text_expansion_multiplier)));
+    } else {
+        //t.setAttribute("textLength", t.getBBox().width);
+        g.setAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "syntaxdiagram2svg:width", (t.getBBox().width * syntaxdiagram_Constants.text_expansion_multiplier));
+    }
     g.setAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "syntaxdiagram2svg:heightAbove", 0 - (t.getBBox().y) - syntaxdiagram_Constants.text_baseline_shift);
     g.setAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "syntaxdiagram2svg:heightBelow", (t.getBBox().height + (t.getBBox().y - 0) + syntaxdiagram_Constants.text_baseline_shift));
-    // Tell this text how long it was, in case it is being rendered later with a different renderer.
-    t.setAttribute("textLength", t.getBBox().width);
   }
   else
   {
-    g.setAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "syntaxdiagram2svg:width", 0);
-    g.setAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "syntaxdiagram2svg:heightAbove", 0);
-    g.setAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "syntaxdiagram2svg:heightBelow", 0);
+    g.setAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "syntaxdiagram2svg:width", 4.9);
+    g.setAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "syntaxdiagram2svg:heightAbove", 2.5);
+    g.setAttributeNS("http://www.moldflow.com/namespace/2008/syntaxdiagram2svg", "syntaxdiagram2svg:heightBelow", 3);
   }
 }
 

--- a/com.moldflow.dita.syntaxdiagram2svg/resource/constants.xml
+++ b/com.moldflow.dita.syntaxdiagram2svg/resource/constants.xml
@@ -9,6 +9,9 @@
     <scalar name="box_padding_vertical">4</scalar>
     <scalar name="box_padding_horizontal">4</scalar>
     
+    <!-- Factor by which to increase text space to allow for font expansion -->
+    <scalar name="text_expansion_multiplier">1.05</scalar>
+    
     <!-- Corner radius for boxes, per element. -->
     <array name="box_corner_radius">
         <scalar name="kwd">3</scalar>

--- a/com.moldflow.dita.syntaxdiagram2svg/resource/constantsPDF.xml
+++ b/com.moldflow.dita.syntaxdiagram2svg/resource/constantsPDF.xml
@@ -9,6 +9,9 @@
     <scalar name="box_padding_vertical">4</scalar>
     <scalar name="box_padding_horizontal">4</scalar>
     
+    <!-- Factor by which to increase text space to allow for font expansion -->
+    <scalar name="text_expansion_multiplier">1.05</scalar>
+    
     <!-- Corner radius for boxes, per element. -->
     <array name="box_corner_radius">
         <scalar name="kwd">3</scalar>


### PR DESCRIPTION
Major updates to JS code accumulated over the last year of development, finally bringing up to date with this copy:

- Several minor fixes, largely around spacing
- Updates to use Plex and Unicode fonts by default, with existing Arial / Helvetica still present as fallback
- Add unique class to each boxed component, which disables display of the box border for most components (keeping them for `fragref`)
- Add unique class to arrows based on their purpose; hide most arrows, apart from start/end and repeating groups